### PR TITLE
docs: expand terminology, add Markov regime + earnings playbook references

### DIFF
--- a/docs/common/README.md
+++ b/docs/common/README.md
@@ -7,6 +7,8 @@ Use these docs as references in project-specific design docs.
 - [Trading Strategies](./trading-strategies.md)
 - [Market Internals](./market-internals.md)
 - [Indicators Reference](./indicators.md)
+- [Regime Detection](./regime-detection.md)
+- [Earnings Playbook](./earnings-playbook.md)
 - [Data Sources](./data-sources.md)
 - [Tools Comparison](./tools-comparison.md)
 - [Risk and Position Sizing](./risk-and-position-sizing.md)

--- a/docs/common/earnings-playbook.md
+++ b/docs/common/earnings-playbook.md
@@ -1,0 +1,142 @@
+# Earnings Playbook (Generic)
+
+> Educational reference for analyzing earnings events and selecting strategy by historical pattern, not just IV environment.
+
+## The Two Numbers That Drive Strategy Choice
+
+For any earnings event, two historical statistics dominate strategy selection over the standard "high IV → sell premium" heuristic:
+
+### 1) Direction Bias
+
+```
+Direction Bias = (number of UP D1 prints) / (last N prints)
+```
+
+Where `D1` is the next-trading-day return (close-to-close from the *anchor* price, defined below).
+
+| Direction Bias | Tilt |
+|---|---|
+| ≥ 7/8 UP (≥ 87%) | Strong bullish bias — favor bull put spreads / long calls; deprioritize neutral structures |
+| 5–6/8 UP | Mild bullish; iron condors still acceptable but skew them |
+| ~4/8 either way | No directional edge; pure IV/PoP analysis |
+| ≥ 7/8 DOWN | Strong bearish bias — favor bear call spreads / long puts |
+
+### 2) Beat-Implied Rate
+
+```
+Beat-Implied Rate = (number of prints where |actual D1| > implied move) / (last N prints)
+```
+
+Where the *implied move* is the pre-event ATM-straddle-derived 1σ expectation.
+
+| Beat-Implied Rate | Tilt |
+|---|---|
+| > 60% | Long premium has structural edge — actual exceeds implied. Long straddles / strangles or directional debit spreads. |
+| 40–60% | No premium edge — IV environment alone drives choice. |
+| < 40% | Short premium has structural edge — iron condors, credit spreads. Realized < implied historically. |
+
+**Override rule:** If a stock has 6+/8 quarters where actual > implied **and** the IV environment is "high," **buying premium can still be the right play** despite the high IV. The structural realized-vs-implied gap beats the heuristic.
+
+## The Mandatory 8-Quarter Table
+
+For any pre-earnings analysis, build this:
+
+```
+| # | Quarter | Report Date | EPS Est | EPS Act | Surprise % | Anchor $ | Implied | D1 | D5 | Direction | Beat-Implied? |
+```
+
+- **Anchor $** — closing price the trading day before the release.
+- **Implied** — ATM straddle / spot, *pre-event* (i.e., the day of the release, before the print).
+- **D1** — return from anchor to next-day close.
+- **D5** — return from anchor to 5-trading-day close.
+- **Direction** — UP / DOWN based on D1 sign.
+- **Beat-Implied?** — `✅` if `|D1| > implied`, `❌` if `|D1| < implied`.
+
+## D1 vs D5 — Why It Matters
+
+D1 captures the immediate IV-crush + initial directional reaction. D5 captures the market's digestion. They often diverge:
+
+- **D1 small, D5 large** — slow-digestion stock (e.g., large-cap industrials). Short-premium structures should be **closed at D1 close**, not held to weekly expiry.
+- **D1 large, D5 partial reversal** — fast money piles in then unwinds. Long-premium structures should harvest the D1 spike; don't hold for trend.
+- **D1 large, D5 trend continuation** — narrative-driven move. Long calls / puts can extend.
+
+## Strategy Backtest (Per Quarter)
+
+For each of the last 8 quarters, evaluate which structure *would have won* at ~1σ implied strikes, weekly expiry, D1 close:
+
+| Strategy | Wins if … |
+|---|---|
+| Iron Condor | `|D1| < implied` (any direction) |
+| Bull Put Spread | D1 ≥ 0 (or modestly positive) |
+| Bear Call Spread | D1 ≤ 0 (or modestly negative) |
+| Long Straddle | `|D1| > implied` (any direction) |
+| Long Call | D1 large positive (covers premium) |
+| Long Put | D1 large negative (covers premium) |
+
+Sum wins across the 8 quarters to get a **historical PoP per strategy**. Lead recommendations with the highest-PoP structure — don't default to "high IV = sell premium" without checking.
+
+## Sector Read-Through
+
+A print rarely happens in isolation. Before finalizing recommendations:
+
+1. **Sector leader within ±3 trading days?** A bellwether print (NVDA for AI semis, JPM for banks, AAPL for consumer tech, AMAT for WFE) drives sympathy in peers.
+2. **Macro releases within the window?** FOMC, CPI, PPI, GDP, NFP — any of these can dwarf single-stock prints.
+3. **Same-day cluster?** Multiple sector peers on the same day = doubly correlated reactions.
+
+Document which way the read-through flows: "X reports BEFORE this stock → reaction sets the tone" vs "this stock reports first → sets the tone for peers."
+
+## Sell-the-News Pattern
+
+Stocks with **consistent D1 weakness despite EPS beats** are exhibiting "sell the news" — positioning was already extreme entering the print. The trade tells:
+
+- Direction Bias < 30% UP despite Beat Rate > 60% = textbook sell-the-news.
+- Strategy: bear call spreads or iron condors with bearish skew, not bull put spreads.
+- Why it happens: institutional positioning is fully extended; even good results aren't a marginal buy catalyst.
+
+## Gap & Fill
+
+Many stocks gap on D1 and then partially retrace by D5. If D1 and D5 frequently disagree in sign:
+
+- Short-premium plays must close by D1 (D5 reversals can re-open breached strikes).
+- Long-premium plays must be sized to take profit on D1 spike — don't trail for the full move.
+
+## Pre-Earnings IV Behavior
+
+Expect IV to rise into the print (especially in the final 5–7 trading days) and **crush** sharply on the open after the release. Two operational consequences:
+
+1. **Build short-premium structures ~7–10 days before the print** to capture the IV expansion *and* the post-print crush.
+2. **Never hold long premium through earnings** unless you've explicitly modeled the IV crush impact on your specific structure. Direction can be right and the position still loses if IV collapses faster than spot moves.
+
+## Earnings Strategy Selection Matrix
+
+| Direction Bias | Beat-Implied Rate | Lead Strategy |
+|---|---|---|
+| ≥ 7/8 UP | < 40% | **Bull put spread** at ~1σ strikes |
+| ≥ 7/8 UP | > 60% | **Long call / bull debit spread** (cheap optionality on structural edge) |
+| ~4/8 | < 40% | **Iron condor** at ~1σ strikes |
+| ~4/8 | > 60% | **Long straddle / strangle** |
+| ≥ 7/8 DOWN | < 40% | **Bear call spread** at ~1σ strikes |
+| ≥ 7/8 DOWN | > 60% | **Long put / bear debit spread** |
+
+> Always cross-check with the current Markov regime — earnings tilts can be overridden by a sticky-regime hard gate (e.g., never sell calls in sticky bull, never sell puts in sticky bear).
+
+## Required Pre-Trade Documentation
+
+For each earnings setup, record:
+
+- Confirmed earnings date and BMO/AMC timing
+- Anchor price (yesterday's close)
+- Implied move from two independent sources (flag any > 2% spread)
+- 8-quarter historical table with both required statistics
+- Strategy backtest table and identified lead strategy
+- Sector read-through events within ±3 trading days
+- Existing portfolio positions correlated to this print
+- Specific strikes, expiry, credit/debit, breakeven, max profit, max loss, PoP
+
+If any field is missing, the trade is not ready.
+
+## See Also
+
+- [Trading Strategies](./trading-strategies.md) — named-spread mechanics
+- [Indicators Reference](./indicators.md) — IV, skew, term structure
+- [Regime Detection](./regime-detection.md) — Markov overlay that can override the earnings tilt

--- a/docs/common/earnings-playbook.md
+++ b/docs/common/earnings-playbook.md
@@ -79,7 +79,7 @@ Sum wins across the 8 quarters to get a **historical PoP per strategy**. Lead re
 
 A print rarely happens in isolation. Before finalizing recommendations:
 
-1. **Sector leader within ±3 trading days?** A bellwether print (NVDA for AI semis, JPM for banks, AAPL for consumer tech, AMAT for WFE) drives sympathy in peers.
+1. **Sector leader within ±3 trading days?** A bellwether print — for example, the largest-cap or most-watched name in the relevant cluster (semis, banks, consumer tech, wafer-fab equipment, etc.) — drives sympathy in peers.
 2. **Macro releases within the window?** FOMC, CPI, PPI, GDP, NFP — any of these can dwarf single-stock prints.
 3. **Same-day cluster?** Multiple sector peers on the same day = doubly correlated reactions.
 

--- a/docs/common/glossary.md
+++ b/docs/common/glossary.md
@@ -1,11 +1,119 @@
 # Trading Glossary (Generic)
 
-- `ATM`: At-the-money option strike near current underlying price.
-- `Expected Move`: Move implied by near-event option pricing (often approximated by ATM straddle value).
-- `IV Crush`: Sharp decline in implied volatility after uncertainty resolves (e.g., post earnings).
-- `IV Rank`: Position of current IV in a historical range.
-- `BMO`: Before market open earnings release.
-- `AMC`: After market close earnings release.
-- `GEX`: Gamma exposure context, often used as a market microstructure signal.
-- `Liquidity Score`: Composite of spread, volume, and open interest quality.
-- `Defined Risk`: Option structure where maximum loss is bounded.
+> Educational reference. Definitions describe concepts in their most common usage; specific platforms or strategies may use them more narrowly.
+
+## Options — Basics
+
+- `ATM` (At-the-money): Option strike near the current underlying price.
+- `ITM` (In-the-money): Call with strike below spot, or put with strike above spot (intrinsic value > 0).
+- `OTM` (Out-of-the-money): Call with strike above spot, or put with strike below spot (intrinsic value = 0).
+- `DTE` (Days to Expiration): Calendar days remaining until the option expires.
+- `Strike`: The fixed price at which the option's right can be exercised.
+- `Premium`: The price paid (debit) or received (credit) for an option contract.
+- `Width`: Distance in dollars between the long and short strikes of a vertical spread (e.g., a $440/$460 spread has width $20).
+- `Wing`: Either of the long protective strikes in a multi-leg structure (the strikes that cap loss).
+- `Credit / Debit`: A position is a *credit spread* if entered for net cash received; *debit spread* if entered for net cash paid.
+- `Assignment`: Obligation to fulfill the option (deliver shares for short call, buy shares for short put) when the holder exercises.
+- `Roll`: Closing an existing option and opening a new one with a different strike or expiration to manage the position.
+
+## Options — Spreads & Structures
+
+- `Bull Put Spread (BPS)`: Sell a put + buy a lower-strike put, same expiry. Credit. Profits if underlying stays above the short strike. Defined risk.
+- `Bear Call Spread (BCS)`: Sell a call + buy a higher-strike call, same expiry. Credit. Profits if underlying stays below the short strike. Defined risk.
+- `Bull Call Spread`: Buy a call + sell a higher-strike call. Debit. Profits if underlying rises toward the short strike.
+- `Bear Put Spread`: Buy a put + sell a lower-strike put. Debit. Profits if underlying falls toward the short strike.
+- `Iron Condor`: Bull put spread + bear call spread, both OTM, same expiry. Credit. Profits if underlying stays between the short strikes.
+- `Iron Butterfly`: Same as iron condor but the short strikes are at the same price (ATM). Larger credit, narrower profit zone.
+- `Short Strangle`: Sell an OTM call + sell an OTM put (no long wings). Undefined risk.
+- `Long Straddle`: Buy ATM call + buy ATM put. Profits if move exceeds combined premium in either direction.
+- `Long Strangle`: Buy OTM call + buy OTM put. Cheaper than a straddle, requires larger move to profit.
+- `Calendar Spread`: Sell near-dated option + buy farther-dated option, same strike. Profits from time decay differential and steady IV.
+- `Call Diagonal / Put Diagonal`: Like a calendar but with different strikes (one OTM, one further out and longer-dated).
+- `Cash-Secured Put (CSP)`: Sell a put while holding enough cash to buy the shares if assigned. Income strategy; effectively "get paid to set a limit-buy."
+- `Covered Call`: Sell a call against owned shares. Income strategy; caps upside above strike.
+
+## The Greeks (sensitivities)
+
+- `Delta`: Change in option price per $1 move in the underlying. Calls: 0 to +1. Puts: 0 to −1. Also a rough proxy for "probability of finishing ITM" (e.g., 0.30 delta ≈ 30% chance ITM at expiry).
+- `Gamma`: Rate of change of delta. Highest near ATM and near expiry.
+- `Theta`: Daily decay of option price from time alone. Negative for long options, positive for short options.
+- `Vega`: Change in option price per 1 vol-point change in IV. Long options have positive vega; short options have negative vega.
+- `Rho`: Sensitivity to interest rates. Usually small for short-dated equity options.
+
+## Volatility
+
+- `IV` (Implied Volatility): Annualized volatility implied by the current option price, solved from a pricing model.
+- `HV / RV` (Historical / Realized Volatility): Annualized volatility computed from actual historical returns.
+- `IV / HV gap` or `Variance Risk Premium (VRP)`: The structural tendency of IV to exceed RV, on average. The "premium" buyers pay for protection against tail risk — the structural source of edge for net premium sellers.
+- `IV Rank`: Where today's IV sits within its 52-week range. IV Rank 80% = today's IV is higher than 80% of the past year's readings.
+- `IV Percentile`: Fraction of days in the past year where IV was *below* current. Distinct from IV Rank (which is a min/max scaling).
+- `IV Crush`: Sharp decline in IV after the resolution of a known event (earnings, FDA decision, FOMC). Hurts long premium even when direction is right.
+- `Volatility Skew`: Difference in IV across strikes at the same expiry. Equity index puts are usually more expensive than calls (negative / put skew). When **calls are more expensive than puts (call skew)** it signals demand for upside / squeeze pressure.
+- `Term Structure`: Shape of IV across expirations. *Contango* = back-month IV higher than front-month (normal). *Backwardation* = front-month higher (event-driven, e.g., earnings within the front cycle).
+- `Expected Move`: 1σ move implied by ATM straddle pricing. Approximately `straddle price / spot`. The market's consensus range over the option's life.
+- `1σ / 2σ`: One / two standard deviations. Under a log-normal assumption, ~68% of outcomes lie within 1σ, ~95% within 2σ.
+- `Vol Crush` / `Event Vol Crush`: Specific case of IV crush tied to a binary event resolving.
+
+## Trade Quality Metrics
+
+- `PoP` (Probability of Profit): Estimated probability the trade closes profitable. For short-premium spreads, commonly approximated by `1 − |short strike delta|` (chance the short strike expires OTM) or `credit / width` for vertical spreads.
+- `RR` (Risk/Reward Ratio): `max loss / max profit`. An 8:1 RR means you must win 8 out of 9 trades to break even.
+- `Max Profit / Max Loss`: Defined-risk structures have hard caps; undefined-risk structures (short strangles, short puts unsecured) do not.
+- `Breakeven`: Underlying price at expiry where P&L = 0. For credit spreads, `short strike ± credit`. For debit spreads, `long strike ± debit`.
+- `Defined Risk`: Position with a known, bounded maximum loss. Required for any strategy facing tail-event-prone underlyings.
+- `Kelly Criterion / Kelly Sizing`: Mathematical formula for the bet size that maximizes long-run geometric growth given edge and odds. In practice, traders use *fractional Kelly* (¼ to ½ Kelly) to reduce drawdown.
+
+## Pricing Models
+
+- `Black-Scholes`: Closed-form European-option pricing model. Inputs: spot, strike, time, IV, rate, dividend. Assumes log-normal returns and constant volatility — both broken in practice but the model remains the industry baseline for IV/Greeks.
+- `Log-Normal Returns Assumption`: The model's assumption that log-returns are normally distributed. Real markets have fatter tails (left especially) and skew, so true probabilities deviate from model probabilities at the extremes.
+- `Jump Risk`: Idiosyncratic single-day moves not captured by diffusion-based models (e.g., short reports, surprise M&A, regulatory headlines). The reason "modeled PoP" often overstates true PoP for premium sellers.
+
+## Options Flow & Positioning
+
+- `Open Interest (OI)`: Total open contracts at a strike/expiry. Built up over time.
+- `Put/Call Ratio (P/C)`: Total puts / total calls (volume or OI). > 1.0 = bearish positioning; < 0.7 = bullish positioning.
+- `Max Pain`: Strike at which the most options expire worthless — the price level that minimizes payout to option holders. Often acts as a magnet into expiry in low-catalyst weeks.
+- `Call Wall / Put Wall`: Strikes with extreme OI, treated as soft resistance (call wall) or support (put wall) due to dealer hedging flows.
+- `GEX` (Gamma Exposure): Aggregate dealer gamma positioning. Positive GEX dampens volatility (dealers buy dips / sell rips); negative GEX amplifies it.
+- `Unusual Options Activity` / `Sweep`: Large, urgent option trades (often crossing the spread at multiple exchanges simultaneously) that signal directional conviction from informed flow.
+- `Liquidity Score`: Composite of bid/ask spread tightness, volume, and open interest quality. Low liquidity = wide spreads = higher slippage.
+
+## Earnings & Events
+
+- `BMO / AMC`: Before market open / after market close earnings release timing.
+- `Whisper Number`: Unofficial consensus estimate, often more aggressive than published consensus.
+- `Beat / Miss`: Reported EPS or revenue above / below consensus.
+- `Beat-Implied Rate`: Across recent earnings prints, the % of times the actual D1 move exceeded the pre-event implied move. A high rate (>60%) is a structural tell that long-premium has edge into earnings; a low rate (<40%) tells you premium sellers have edge.
+- `Direction Bias`: Across recent earnings prints, the % of D1 moves that were UP (or DOWN). 7+ out of 8 in one direction is a strong directional bias and tilts strategy selection away from neutral.
+- `D1 / D5`: Post-earnings 1-day and 5-day moves. D5 often reverses D1 partially or fully; defines whether the play is short-term "harvest the crush" or longer "trend follow."
+- `Anchor Price`: Closing price the trading day before an earnings release — the reference price for measuring D1/D5 reaction.
+- `Sympathy Move`: Price reaction in a correlated ticker driven by another stock's news/earnings (e.g., AMAT moves on NVDA results).
+- `Read-Through`: Same idea framed as "what does X's print tell us about Y?" — common in sector clusters (semis, banks, hyperscalers, payments).
+- `Sell-the-News`: Pattern where a stock falls on a beat (or rises on a miss) because positioning was already extreme.
+- `Gap & Fill`: Tendency for an earnings gap to be partially or fully retraced within several sessions.
+
+## Regime & Statistical Concepts
+
+- `Regime`: A persistent statistical state of the market — typically Bull, Bear, or Sideways — defined by rolling-return rules or unsupervised clustering.
+- `Markov Regime Model`: Assumes the next regime depends only on the current regime (memoryless). Estimated via a transition matrix of regime-to-regime probabilities.
+- `Transition Matrix`: 3×3 (or N×N) matrix where entry `(i, j)` is the probability of moving from regime `i` to regime `j` in one step.
+- `Persistence Diagonal`: The diagonal of the transition matrix — `P[Bull → Bull]`, `P[Bear → Bear]`, `P[Sideways → Sideways]`. High persistence (> 75%) means the current regime is "sticky."
+- `Stationary Distribution`: Long-run probability of being in each regime. The fraction of time the system spends in each state over an infinite horizon. Solves `π × T = π`.
+- `Sticky Bull / Sticky Bear`: Regime with persistence diagonal > 75%. The state tends to self-perpetuate; bullish/bearish strategies are favored / disfavored accordingly.
+- `Tail-Heavy Regime`: When the stationary probability of the Bear regime exceeds ~40%, suggesting the underlying spends a non-trivial fraction of time in drawdown. Justifies defined-risk-only constraints and reduced sizing.
+- `Regime Signal`: A scalar summary, often `P(Bull next) − P(Bear next)`, in `[−1, +1]`. Positive = bullish conviction, negative = bearish.
+- `Sizing Scalar`: A multiplier (0–1) applied to default contract counts based on regime risk. Common form: `max(0, 1 − bear_baseline)`. Tail-heavy regimes hard-cap to 0.5 or 0.
+- `Hidden Markov Model (HMM)`: A regime model where the regime itself is unobserved (latent) and inferred from returns via Baum-Welch / forward-backward. Adds expressiveness vs explicit-rule regime labels.
+- `Walk-Forward Backtest`: Out-of-sample evaluation where the model is re-fit on a rolling window and tested on the next period — never uses future data to make past decisions.
+- `Sharpe Ratio`: `(mean return − risk-free) / standard deviation of returns`, annualized. Quality measure for a return stream. > 1.0 is good; > 2.0 is rare.
+- `Max Drawdown`: Largest peak-to-trough decline over the backtest period. Drawdown discipline is usually a tighter constraint than Sharpe in practice.
+
+## Risk & Process
+
+- `Defined Risk Only`: A rule used in regimes/tickers with documented tail risk — forbid undefined-risk structures (short strangles, naked short options).
+- `Hard Gate`: A non-negotiable rule that blocks certain strategy families based on state (e.g., "no bullish premium-selling in sticky bear").
+- `Conviction (HIGH / MED / LOW)`: Subjective grade of trade quality combining edge, fit, and timing.
+- `Time Stop`: Exit rule based on calendar/DTE, not P&L (e.g., "close all credit spreads at 21 DTE regardless").
+- `Profit Target`: Mechanical exit at a percentage of max profit (commonly 50% for credit spreads).
+- `Stop Loss`: Mechanical exit at a percentage of max loss or credit received (commonly −150% to −200% of credit).

--- a/docs/common/glossary.md
+++ b/docs/common/glossary.md
@@ -88,7 +88,7 @@
 - `Direction Bias`: Across recent earnings prints, the % of D1 moves that were UP (or DOWN). 7+ out of 8 in one direction is a strong directional bias and tilts strategy selection away from neutral.
 - `D1 / D5`: Post-earnings 1-day and 5-day moves. D5 often reverses D1 partially or fully; defines whether the play is short-term "harvest the crush" or longer "trend follow."
 - `Anchor Price`: Closing price the trading day before an earnings release — the reference price for measuring D1/D5 reaction.
-- `Sympathy Move`: Price reaction in a correlated ticker driven by another stock's news/earnings (e.g., AMAT moves on NVDA results).
+- `Sympathy Move`: Price reaction in a correlated ticker driven by another stock's news or earnings — for example, a wafer-fab equipment supplier reacting to a leading-edge customer's results.
 - `Read-Through`: Same idea framed as "what does X's print tell us about Y?" — common in sector clusters (semis, banks, hyperscalers, payments).
 - `Sell-the-News`: Pattern where a stock falls on a beat (or rises on a miss) because positioning was already extreme.
 - `Gap & Fill`: Tendency for an earnings gap to be partially or fully retraced within several sessions.

--- a/docs/common/indicators.md
+++ b/docs/common/indicators.md
@@ -13,12 +13,38 @@
 
 | Indicator | What It Measures | Typical Interpretation |
 |---|---|---|
-| IV Rank | Current IV vs 1Y range | High IV Rank may favor premium selling |
-| IV Percentile | Frequency rank of IV | Helps compare current IV context |
-| HV/RV | Realized volatility | Use against IV to assess richness/cheapness |
+| IV | Implied volatility from option prices | Forward-looking risk pricing |
+| HV / RV | Historical / realized volatility | Backward-looking actual moves |
+| IV Rank | Current IV vs 1Y min/max range | High IV Rank may favor premium selling |
+| IV Percentile | Frequency rank of IV vs past year | Distinct from IV Rank; uses cumulative distribution |
+| IV / HV Ratio | IV ÷ HV | > 1.0 = options pricing more vol than recently realized |
+| Variance Risk Premium (VRP) | Average IV − RV gap | Structural source of edge for net premium sellers |
+| Volatility Skew | IV difference across strikes (same expiry) | Put skew = downside fear; **Call skew = upside demand / squeeze pressure** |
+| Term Structure | IV across expirations | Contango (normal) vs backwardation (event-driven) |
+| VIX Level + Slope | Index of S&P implied vol | Regime filter; sharp spikes = stress |
+
+## Options Positioning Indicators
+
+| Indicator | What It Measures | Typical Interpretation |
+|---|---|---|
+| Put/Call Ratio | Put volume / call volume (or OI) | > 1.0 = bearish positioning; < 0.7 = bullish |
+| Max Pain | Strike with greatest aggregate option-holder loss at expiry | Magnet effect into low-catalyst expirations |
+| Call Wall / Put Wall | Strike with extreme OI | Soft resistance / support from dealer hedging |
+| GEX | Aggregate dealer gamma exposure | Positive GEX dampens vol; negative amplifies |
+
+## Regime Indicators (see also: [Regime Detection](./regime-detection.md))
+
+| Indicator | What It Measures | Typical Interpretation |
+|---|---|---|
+| Regime label (Bull / Bear / Sideways) | State from rolling returns or HMM | Drives strategy family selection |
+| Persistence diagonal | P[regime → same regime] | > 75% = "sticky"; favors trend-following / premium-selling |
+| Regime signal | P(Bull next) − P(Bear next), in [−1, 1] | Sign = direction; magnitude = conviction |
+| Stationary distribution | Long-run fraction of time per regime | Bear baseline > 40% = tail-heavy; force defined-risk |
+| Walk-forward Sharpe / Max Drawdown | Out-of-sample regime-signal backtest | Quality check on the regime classifier itself |
 
 ## Usage Notes
 
 - Indicators are context tools; avoid single-indicator decisions.
 - Keep threshold logic in rulebooks and version those thresholds.
 - Validate indicator utility per ticker/regime via out-of-sample tests.
+- Skew and term-structure inversions often signal known upcoming events (earnings, FDA, macro releases) — verify before assuming structural meaning.

--- a/docs/common/regime-detection.md
+++ b/docs/common/regime-detection.md
@@ -1,0 +1,131 @@
+# Regime Detection (Markov Framework)
+
+> Generic educational reference for using Markov-style regime models as a filter on top of a strategy selection process.
+
+## Concept
+
+Markets shift between persistent statistical *regimes* — typically labeled **Bull**, **Bear**, **Sideways** — where return distributions, correlations, and volatility levels are materially different. Selling premium in a sticky Bear regime is one of the most common ways to blow up an options book; the same trade in a Bull regime can be the best risk-adjusted setup on the board. A regime model is a filter for choosing the **right strategy family for the current state**.
+
+## Labeling Returns
+
+The simplest approach: label each day's regime from a rolling-return rule.
+
+```
+window = 20 trading days
+threshold = 5%
+
+rolling_return[t] = close[t] / close[t - window] - 1
+
+regime[t]:
+  Bull     if rolling_return[t] >  +threshold
+  Bear     if rolling_return[t] <  −threshold
+  Sideways otherwise
+```
+
+More expressive variants:
+- **Hidden Markov Model (HMM)** — regime is latent; inferred from returns via Baum-Welch / forward-backward.
+- **Gaussian Mixture / change-point models** — useful when returns are heavy-tailed.
+
+The rolling-return rule has the advantage of being interpretable and label-stable; HMMs can overfit if not regularized.
+
+## The Transition Matrix
+
+Estimate `T[i, j] = P(regime_{t+1} = j | regime_t = i)` by simple maximum-likelihood (count transitions, normalize rows). For a 3-state model:
+
+```
+            Bull    Sideways   Bear
+   Bull   [ 0.89    0.10       0.01 ]
+Sideways  [ 0.24    0.58       0.18 ]
+   Bear   [ 0.01    0.10       0.89 ]
+```
+
+Key quantities to read off the matrix:
+
+| Quantity | How to read it | Why it matters |
+|---|---|---|
+| `Persistence diagonal` | `T[i, i]` for each `i` | Values > 0.75 = "sticky" regime; favors strategies aligned with current state |
+| `Next-step distribution` | Row `T[current, :]` | The probability you're in each regime tomorrow |
+| `n-step distribution` | `current_one_hot @ T^n` (Chapman-Kolmogorov) | Forward forecast |
+| `Stationary distribution π` | Solve `π × T = π`, `Σπ = 1` | Long-run fraction of time in each regime |
+
+## The Regime Signal
+
+Reduce the next-step distribution to a single scalar for strategy selection:
+
+```
+signal = P(Bull next) − P(Bear next)        # ∈ [−1, +1]
+```
+
+- `signal > +0.30` — strong bullish conviction
+- `−0.10 < signal < +0.10` — flat / sideways
+- `signal < −0.30` — strong bearish conviction
+
+## Tail-Heavy Diagnostic
+
+The **stationary probability of the Bear regime** is the structural drawdown indicator:
+
+| `π[Bear]` | Read | Action |
+|---|---|---|
+| < 0.25 | Healthy long-run distribution | Normal sizing |
+| 0.25 – 0.40 | Elevated bear baseline | Reduce sizing scalar to `1 − π[Bear]` |
+| > 0.40 | **Tail-heavy** | Defined-risk only; force scalar to 0.5 or hard-cap to 0 for undefined-risk structures |
+
+## Mapping Regime → Strategy Family
+
+| Regime + Signal | Preferred family | Avoid |
+|---|---|---|
+| Bull, `signal > +0.30` | Bull put spreads, CSP, long calls (low IV), call diagonals | Bear call spreads, long puts |
+| Bull, `signal ∈ [0, +0.30]` | Bull call spreads, modest bull put spreads | Naked short puts |
+| Sideways, `\|signal\| < 0.10` | Iron condors, iron butterflies, calendar spreads, covered calls | Long single options (theta bleed) |
+| Bear, `signal < −0.30` | Bear call spreads, long puts (low IV), bear put spreads, protective puts | CSP, bull put spreads, short strangles |
+| Bear, `signal ∈ [−0.30, 0]` | Bear put spreads (defined risk) | Naked short calls |
+| Tail-heavy (any regime) | Defined-risk only; reduce contract count by 50%+ | Undefined-risk premium sells |
+
+## Hard Gates
+
+These are non-negotiable rules — not "consider context first."
+
+1. **Sticky Bear hard gate.** If `current_regime == Bear` AND `T[Bear, Bear] > 0.75`, **do not** open bull put spreads or cash-secured puts. Selling puts into a sticky bear is the classic blow-up pattern.
+2. **Sticky Bull symmetric gate.** If `current_regime == Bull` AND `T[Bull, Bull] > 0.75`, **do not** open bear call spreads. Selling calls into a sticky bull bleeds slowly until it bleeds catastrophically.
+3. **Undefined-risk cap.** Tail-heavy regimes (`π[Bear] > 0.40`) force a hard ban on undefined-risk structures (short strangles, naked short options) regardless of regime sign.
+
+## Sizing
+
+Apply the regime-derived sizing scalar to default contract counts:
+
+```
+scalar = max(0, 1 − π[Bear])
+
+if tail_heavy:           # π[Bear] > 0.40
+    scalar = min(scalar, 0.5)
+    scalar = 0 for undefined-risk structures
+
+contracts = round(default_contracts × scalar)
+```
+
+The scalar reduces position size in proportion to the long-run drawdown probability — a structural haircut that protects against fat-tail single-stock risk.
+
+## Quality Checks on the Regime Model Itself
+
+| Check | What | Pass criterion |
+|---|---|---|
+| Walk-forward Sharpe | Re-fit on rolling window; evaluate next period only | Positive Sharpe on out-of-sample regime signal |
+| Walk-forward Max Drawdown | Same backtest | Drawdown discipline: < the underlying's buy-and-hold DD |
+| Sample size per regime | Count of days labeled each state | At least 50 observations per regime |
+| Transition matrix stability | Re-estimate on subsamples; compare | Diagonal entries should not flip dramatically |
+
+A regime model with negative walk-forward Sharpe is not a filter — it's noise. Validate before deploying it as a hard gate.
+
+## Caveats
+
+- **No look-ahead in labeling.** Use only data available at time `t` when computing `regime[t]`. The rolling window must be backward-only.
+- **HMM Baum-Welch finds local optima.** Run multiple `random_state` initializations and pick the best by likelihood.
+- **HMM regime labels are not semantic.** "Bear" in an HMM is "lowest-mean state" — could still be positive return in a strong bull market. Label by `mean(state_returns)` and disclose.
+- **Past persistence ≠ future persistence.** Regime models are descriptive of the training period; structural breaks (policy shifts, mega-cap dominance changes) can invalidate them.
+- **Backtests are historical, not forward-looking.** Always pair the regime overlay with defined-risk structures so the model failing doesn't take down the book.
+
+## See Also
+
+- [Trading Strategies](./trading-strategies.md) — strategy families filtered by this matrix
+- [Indicators Reference](./indicators.md) — regime indicators in the broader indicator panel
+- [Risk and Position Sizing](./risk-and-position-sizing.md) — sizing rules that consume the scalar

--- a/docs/common/trading-strategies.md
+++ b/docs/common/trading-strategies.md
@@ -8,7 +8,7 @@ This document summarizes strategy families and when they are generally considere
 ### 1) Directional
 - Long stock / short stock
 - Long call / long put
-- Debit spreads
+- Debit spreads (bull call, bear put)
 
 Use when directional conviction is high and timing edge exists.
 
@@ -47,3 +47,122 @@ Use after uncertainty clears and post-event regime is observable.
 - Max loss is known and acceptable.
 - Time stop and hard stop are set.
 - Exit criteria are mechanical, not discretionary.
+
+---
+
+## Named Vertical Spread Reference
+
+Vertical spreads are the workhorse of defined-risk options trading. All four are pairs of same-expiry options at different strikes.
+
+### Bull Put Spread (BPS) — Credit, Bullish/Neutral
+
+| Field | Value |
+|---|---|
+| Construction | Sell put @ K_short, Buy put @ K_long where K_long < K_short |
+| Net | Credit |
+| Outlook | Bullish or sideways (underlying stays above K_short) |
+| Max profit | Credit received |
+| Max loss | (K_short − K_long) − credit |
+| Breakeven | K_short − credit |
+| Best regime | High IV + Bull or Sideways regime |
+| PoP approx | `1 − |delta of K_short|` |
+
+### Bear Call Spread (BCS) — Credit, Bearish/Neutral
+
+| Field | Value |
+|---|---|
+| Construction | Sell call @ K_short, Buy call @ K_long where K_long > K_short |
+| Net | Credit |
+| Outlook | Bearish or sideways (underlying stays below K_short) |
+| Max profit | Credit received |
+| Max loss | (K_long − K_short) − credit |
+| Breakeven | K_short + credit |
+| Best regime | High IV + Bear or Sideways regime |
+| PoP approx | `1 − |delta of K_short|` |
+
+### Bull Call Spread — Debit, Directional Bullish
+
+| Field | Value |
+|---|---|
+| Construction | Buy call @ K_long, Sell call @ K_short where K_short > K_long |
+| Net | Debit |
+| Outlook | Bullish (need underlying to rise toward K_short) |
+| Max profit | (K_short − K_long) − debit |
+| Max loss | Debit paid |
+| Breakeven | K_long + debit |
+| Best regime | Low/Moderate IV + Bull regime |
+
+### Bear Put Spread — Debit, Directional Bearish
+
+| Field | Value |
+|---|---|
+| Construction | Buy put @ K_long, Sell put @ K_short where K_short < K_long |
+| Net | Debit |
+| Outlook | Bearish (need underlying to fall toward K_short) |
+| Max profit | (K_long − K_short) − debit |
+| Max loss | Debit paid |
+| Breakeven | K_long − debit |
+| Best regime | Low/Moderate IV + Bear regime |
+
+---
+
+## Income / Wheel Strategies
+
+### Cash-Secured Put (CSP)
+
+| Field | Value |
+|---|---|
+| Construction | Sell put @ K, hold cash = K × 100 per contract |
+| Net | Credit |
+| Outlook | Bullish/neutral; willing to own at effective price (K − credit) |
+| Max profit | Credit received |
+| Max loss | (K − credit) × 100 per contract (if underlying → 0) |
+| Capital | Full strike value tied up |
+| Use case | Income on stocks you want to own at a discount; first leg of the "wheel" |
+
+### Covered Call
+
+| Field | Value |
+|---|---|
+| Construction | Own 100 shares + sell 1 call @ K |
+| Net | Credit |
+| Outlook | Neutral/mildly bullish; willing to cap upside above K |
+| Max profit | (K − cost basis) + credit |
+| Max loss | Cost basis − credit (full stock downside) |
+| Use case | Yield enhancement on long stock; second leg of the "wheel" |
+
+---
+
+## Diagonal & Calendar Spreads
+
+### Long Call Diagonal
+
+| Field | Value |
+|---|---|
+| Construction | Buy back-month call @ K_long, Sell front-month call @ K_short ≥ K_long |
+| Net | Debit |
+| Outlook | Moderately bullish, gradual drift toward K_short |
+| Max profit | Often realized when front-month expires near K_short and back-month still rich |
+| Max loss | Debit paid (defined) |
+| Use case | Bullish + benefit from front-month theta decay |
+
+### Long Put Diagonal
+
+Mirror of call diagonal for bearish drift.
+
+### Calendar Spread
+
+Same strike, different expiries (sell front, buy back). Profits from front-month theta and a relatively stable IV term structure.
+
+---
+
+## Strategy Selection: IV + Direction Matrix
+
+| Outlook \ IV | Low IV | Moderate IV | High IV |
+|---|---|---|---|
+| Bullish | Long call, Bull call spread | Bull call spread, Call diagonal | **Bull put spread**, CSP |
+| Bearish | Long put, Bear put spread | Bear put spread | **Bear call spread** |
+| Neutral | Calendar spread | Iron condor (wide) | **Iron condor**, Iron butterfly |
+| High-Vol Expected | Long straddle, Long strangle | Long strangle | (avoid — premium is rich) |
+
+> See [Regime Detection](./regime-detection.md) for how to overlay a Markov regime filter on this matrix.


### PR DESCRIPTION
## Summary

Expands the common knowledge base with the terminology and frameworks needed for credit-spread / regime-aware options analysis. Pure docs change — no code.

- **Glossary** grows from 10 → ~80 terms, organized into 8 sections (Options Basics, Spreads & Structures, Greeks, Volatility, Trade Quality Metrics, Pricing Models, Flow & Positioning, Earnings, Regime & Stats, Risk & Process)
- **Trading Strategies** gains a named vertical-spread reference (Bull Put / Bear Call / Bull Call / Bear Put), Cash-Secured Put, Covered Call, diagonals/calendars, and an IV-vs-direction strategy matrix
- **Indicators** adds IV/HV ratio, Variance Risk Premium, Volatility Skew (incl. call skew), Term Structure, P/C ratio, Max Pain, Call/Put Walls, GEX, and a Regime Indicators table
- **New — Regime Detection** (`regime-detection.md`): Markov framework with transition matrix, persistence diagonal, stationary distribution, regime signal, hard gates (sticky bull / sticky bear), sizing scalar, walk-forward quality checks, caveats
- **New — Earnings Playbook** (`earnings-playbook.md`): Direction Bias and Beat-Implied Rate as the two stats that override the "high IV = sell premium" default; 8-quarter table format; D1/D5 patterns; sector read-through; sell-the-news; strategy selection matrix
- README index updated

## Motivation

Practitioner-facing options analyses kept reaching for terms (PoP, RR, skew, persistence diagonal, Beat-Implied Rate, D1/D5, sizing scalar, etc.) that weren't in the shared glossary. Documenting them generically here removes ambiguity across downstream project docs.

## Scope guardrails

- Stays generic and educational per the repo's `Usage Rule`
- No project-specific strategies, private drafts, or proprietary execution plans
- Cross-links between docs (Trading Strategies ↔ Regime Detection ↔ Earnings Playbook ↔ Indicators)

## Test plan

- [ ] Render each new/edited markdown file and verify tables format correctly on GitHub
- [ ] Skim cross-links between docs (Regime Detection ↔ Trading Strategies ↔ Earnings Playbook ↔ Indicators) and confirm anchors resolve
- [ ] Confirm no proprietary / ticker-specific content leaked in (educational scope only)
- [ ] Spot-check glossary definitions against any duplicated terms in existing SPY-* docs for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)